### PR TITLE
feat: count to time timer mode

### DIFF
--- a/src/components/Time/Time.tsx
+++ b/src/components/Time/Time.tsx
@@ -1,50 +1,197 @@
-import React, { ChangeEvent, KeyboardEvent, FocusEvent } from 'react';
+import React, {
+  ChangeEvent,
+  KeyboardEvent,
+  FocusEvent,
+  useState,
+  useEffect
+} from 'react';
 import styles from './time.module.css';
 import { Mode } from '../ModeSwitch/ModeSwitch';
+import { MAX_TIMER_SECONDS, MAX_CLOCK_MINUTES } from '../../constants/timer';
 
 interface TimeProps {
-  seconds: string;
-  timerInitial: string;
-  milliseconds: string;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  readOnly: boolean;
-  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-  onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
-  onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  seconds: number;
+  timerInitial: number;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onFocus: (e: FocusEvent<HTMLInputElement>) => void;
+  onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+  onWaveDashClick: () => void;
   mode: Mode;
+  isCountToTimer: boolean;
+  countTo: number | null;
+  isEditable: boolean;
+  isEditing: boolean;
 }
+
+export const TimerSubTextMode = {
+  TimerInitial: 'timerInitial',
+  SecondsTail: 'secondsTail'
+} as const;
+
+export type TimerSubTextMode =
+  (typeof TimerSubTextMode)[keyof typeof TimerSubTextMode];
 
 const Time: React.FC<TimeProps> = ({
   seconds,
   timerInitial,
-  milliseconds,
   onChange,
-  readOnly,
   onKeyDown,
   onFocus,
   onBlur,
-  mode
-}) => (
-  <div className={styles.timeContainer}>
-    <div className={styles.placeholder}></div>
-    <input
-      className={`${styles.input}`}
-      value={seconds}
-      onChange={onChange}
-      onKeyDown={onKeyDown}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      readOnly={true}
-      onDragStart={e => e.preventDefault()}
-      onMouseDown={readOnly ? e => e.preventDefault() : undefined}
-    />
-    {mode === Mode.Stopwatch && (
-      <span className={styles.milliseconds}>.{milliseconds}</span>
-    )}
-    {mode === Mode.Timer && (
-      <span className={styles.timerInitial}>/{timerInitial}</span>
-    )}
-  </div>
-);
+  onWaveDashClick,
+  mode,
+  isCountToTimer,
+  countTo,
+  isEditable,
+  isEditing
+}) => {
+  const [timerSubTextSwitch, setTimerSubTextSwitch] =
+    useState<TimerSubTextMode>(TimerSubTextMode.TimerInitial);
+
+  useEffect(() => {
+    if (isEditing) {
+      // By default, show timer initial time when editing
+      setTimerSubTextSwitch(TimerSubTextMode.TimerInitial);
+    } else {
+      // After editing, switch to seconds tail
+      setTimerSubTextSwitch(TimerSubTextMode.SecondsTail);
+    }
+  }, [isEditing]);
+
+  // Seconds -> 12:00 (HH:mm or MM:SS)
+  const formatTime = (secs: number) => {
+    const secsInt = Math.max(0, Math.floor(secs));
+    const h = Math.floor(secsInt / 3600)
+      .toString()
+      .padStart(2, '0');
+    const m = Math.floor((secsInt % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    const s = (secsInt % 60).toString().padStart(2, '0');
+    return h !== '00' ? `${h}:${m}` : `${m}:${s}`;
+  };
+
+  // Seconds -> 12h00 or 59m00
+  const formatTimeS = (secs: number) => {
+    const secsInt = Math.max(0, Math.floor(secs));
+    const h = Math.floor(secsInt / 3600)
+      .toString()
+      .padStart(2, '0');
+    const m = Math.floor((secsInt % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    const s = (secsInt % 60).toString().padStart(2, '0');
+    return h !== '00' ? `${h}h${m}` : `${m}m${s}`;
+  };
+
+  // Minutes -> 12:00 (HH:mm)
+  const formatTimeC = (minutes: number | null) => {
+    if (minutes === null) {
+      return '00:00';
+    }
+    const totalSeconds = Math.max(0, Math.floor(minutes * 60));
+    const h = Math.floor(totalSeconds / 3600)
+      .toString()
+      .padStart(2, '0');
+    const m = Math.floor((totalSeconds % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    return `${h}:${m}`;
+  };
+
+  // Get latest count to timer remaining time, calculate from current time
+  const getCountToTime = () => {
+    // Current time in minutes
+    const now = new Date();
+    const currentTimeInMinutes = now.getHours() * 60 + now.getMinutes();
+    const countToInMinutes = Math.min(countTo ?? 0, MAX_CLOCK_MINUTES);
+    let totalMinutes = countToInMinutes - currentTimeInMinutes;
+    if (totalMinutes < 0) {
+      totalMinutes += 24 * 60;
+    }
+    return Math.min(totalMinutes * 60, MAX_TIMER_SECONDS);
+  };
+
+  return (
+    <div className={styles.container}>
+      {mode === Mode.Stopwatch && <div className={styles.placeholder}></div>}
+      {mode === Mode.Timer && isEditing && (
+        <div
+          className={
+            isCountToTimer ? styles.waveDash : styles.waveDashPlaceholder
+          }
+          onClick={onWaveDashClick}
+          onMouseDown={e => e.preventDefault()}
+        >
+          {isCountToTimer ? '~' : null}
+        </div>
+      )}
+      {mode === Mode.Timer && !isEditing && (
+        <div className={styles.placeholder}></div>
+      )}
+      <input
+        className={`${styles.input}`}
+        value={
+          isCountToTimer && isEditing
+            ? formatTimeC(countTo)
+            : formatTime(seconds)
+        }
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        readOnly={true}
+        onDragStart={e => e.preventDefault()}
+        onMouseDown={e => {
+          if (!isEditable) {
+            e.preventDefault();
+          }
+        }}
+      />
+      {mode === Mode.Stopwatch && (
+        <span className={styles.milliseconds}>
+          .
+          {Math.floor((seconds % 1) * 100)
+            .toString()
+            .padStart(2, '0')}
+        </span>
+      )}
+      {mode === Mode.Timer &&
+        timerSubTextSwitch === TimerSubTextMode.TimerInitial && (
+          <span
+            className={styles.timerInitial}
+            onClick={() => {
+              setTimerSubTextSwitch(TimerSubTextMode.SecondsTail);
+            }}
+          >
+            /
+            {isCountToTimer
+              ? formatTimeS(getCountToTime())
+              : formatTimeS(timerInitial)}
+          </span>
+        )}
+      {mode === Mode.Timer &&
+        timerSubTextSwitch === TimerSubTextMode.SecondsTail && (
+          <span
+            className={styles.timerInitial}
+            onClick={() => {
+              setTimerSubTextSwitch(TimerSubTextMode.TimerInitial);
+            }}
+          >
+            {seconds > 3600
+              ? ':' +
+                Math.floor(seconds % 60)
+                  .toString()
+                  .padStart(2, '0')
+              : '.' +
+                Math.floor((seconds % 1) * 100)
+                  .toString()
+                  .padStart(2, '0')}
+          </span>
+        )}
+    </div>
+  );
+};
 
 export default Time;

--- a/src/components/Time/time.module.css
+++ b/src/components/Time/time.module.css
@@ -14,23 +14,47 @@
   }
 }
 
-.timeContainer {
+.container {
+  height: 92px;
   display: flex;
-  align-items: baseline;
+  align-items: center;
 }
 
 .milliseconds {
   width: 40px;
+  height: 56px;
   font-size: var(--font-size-time-sub);
   color: var(--text-color-secondary);
+  display: flex;
+  align-items: flex-end;
 }
 
 .timerInitial {
   width: 40px;
+  height: 56px;
   font-size: var(--font-size-time-sub);
   color: var(--text-color-secondary);
+  display: flex;
+  align-items: flex-end;
 }
 
 .placeholder {
   width: 40px;
+  height: 60px;
+}
+
+.waveDash {
+  width: 40px;
+  height: 60px;
+  font-size: 56px;
+  color: var(--text-color-secondary);
+  border: 1px dashed var(--text-color-secondary);
+  display: flex;
+  align-items: center;
+}
+
+.waveDashPlaceholder {
+  width: 40px;
+  height: 60px;
+  border: 1px dashed var(--text-color-secondary);
 }

--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -1,2 +1,0 @@
-export const KEY_ENTER = 'Enter';
-export const KEY_NUMPAD_ENTER = 'NumpadEnter';

--- a/src/constants/timer.ts
+++ b/src/constants/timer.ts
@@ -1,0 +1,3 @@
+export const TIMER_INTERVAL_MS = 1;
+export const MAX_TIMER_SECONDS = 99 * 60 * 60 + 59 * 60 + 59; // 99:59:59
+export const MAX_CLOCK_MINUTES = 23 * 60 + 59; // 23:59

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -1,36 +1,62 @@
 import { Mode } from '../components/ModeSwitch/ModeSwitch';
 
-const SECONDS_INIT = 300;
-const MODE_INIT = Mode.Timer;
+const DEFAULT_TIMER_SECONDS = 300;
+const DEFAULT_MODE = Mode.Timer;
+const DEFAULT_IS_COUNT_TO_TIMER = false;
 
 export const getSetting = (key: string) => {
   if (key === 'timer') {
     const time = sessionStorage.getItem('timer');
-    return time ? parseFloat(time) : SECONDS_INIT;
+    return time ? parseFloat(time) : DEFAULT_TIMER_SECONDS;
   }
 
   if (key === 'timerInitial') {
     const time = sessionStorage.getItem('timerInitial');
-    return time ? parseFloat(time) : SECONDS_INIT;
+    return time ? parseFloat(time) : DEFAULT_TIMER_SECONDS;
   }
 
   if (key === 'stopwatch') {
     const time = sessionStorage.getItem('stopwatch');
-    return time ? parseFloat(time) : 0;
+    return time ? parseFloat(time) : 0; // default to 0 seconds
   }
 
   if (key === 'mode') {
     const mode = sessionStorage.getItem('mode');
-    return mode ? (mode as Mode) : MODE_INIT;
+    return mode ? (mode as Mode) : DEFAULT_MODE;
+  }
+
+  if (key === 'isCountToTimer') {
+    const isCountToTimer = sessionStorage.getItem('isCountToTimer');
+    return isCountToTimer
+      ? isCountToTimer === 'true'
+      : DEFAULT_IS_COUNT_TO_TIMER;
+  }
+
+  if (key === 'countTo') {
+    const countTo = sessionStorage.getItem('countTo');
+    return countTo ? parseInt(countTo) : null;
   }
 };
 
-export const setSetting = (key: string, value: string | number) => {
-  if (key === 'timer' || key === 'timerInitial' || key === 'stopwatch') {
+export const setSetting = (key: string, value: string | number | boolean) => {
+  // String
+  if (key === 'inputBuffer') {
+    sessionStorage.setItem('inputBuffer', value as string);
+    return;
+  }
+
+  // Number
+  if (
+    key === 'timer' ||
+    key === 'timerInitial' ||
+    key === 'stopwatch' ||
+    key === 'countTo'
+  ) {
     sessionStorage.setItem(key, value.toString());
     return;
   }
 
+  // Mode
   if (key === 'mode') {
     if (Object.values(Mode).includes(value as Mode)) {
       sessionStorage.setItem(key, value as Mode);
@@ -40,20 +66,26 @@ export const setSetting = (key: string, value: string | number) => {
     return;
   }
 
+  // Boolean
+  if (key === 'isCountToTimer') {
+    sessionStorage.setItem('isCountToTimer', value ? 'true' : 'false');
+    return;
+  }
+
   console.warn(`Unknown setting key: ${key}`);
 };
 
 export const initializeSettings = () => {
   if (sessionStorage.getItem('timer') === null) {
-    sessionStorage.setItem('timer', SECONDS_INIT.toString());
+    sessionStorage.setItem('timer', DEFAULT_TIMER_SECONDS.toString());
   }
   if (sessionStorage.getItem('timerInitial') === null) {
-    sessionStorage.setItem('timerInitial', SECONDS_INIT.toString());
+    sessionStorage.setItem('timerInitial', DEFAULT_TIMER_SECONDS.toString());
   }
   if (sessionStorage.getItem('stopwatch') === null) {
     sessionStorage.setItem('stopwatch', '0');
   }
   if (sessionStorage.getItem('mode') === null) {
-    sessionStorage.setItem('mode', MODE_INIT);
+    sessionStorage.setItem('mode', DEFAULT_MODE);
   }
 };

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -131,7 +131,7 @@ const HomeView = () => {
   useEffect(() => {
     if (isRunning) {
       // Stop the stopwatch if seconds larger than 99:59
-      if (seconds >= MAX_TIMER_SECONDS) {
+      if (seconds > MAX_TIMER_SECONDS) {
         setIsRunning(false);
       }
 

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -21,12 +21,12 @@ import {
   initializeSettings,
   setSetting
 } from '../../utils/settingsUtils';
-import { KEY_ENTER, KEY_NUMPAD_ENTER } from '../../constants/keys';
 import {
   TIMER_INTERVAL_MS,
   MAX_TIMER_SECONDS,
   MAX_CLOCK_MINUTES
 } from '../../constants/timer';
+import { eventKey } from '@linktivity/link-utils';
 
 const HomeView = () => {
   // Mode can be 'timer' or 'stopwatch'
@@ -272,7 +272,7 @@ const HomeView = () => {
   // Handle keydown event
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.code === KEY_ENTER || e.code === KEY_NUMPAD_ENTER) {
+      if (e.key === eventKey.Enter) {
         e.preventDefault();
 
         // Blur input
@@ -334,7 +334,7 @@ const HomeView = () => {
       setupTimer(newBuf);
     }
 
-    if (e.key === 'Backspace') {
+    if (e.key === eventKey.Backspace) {
       e.preventDefault();
       const buf = inputBuffer ?? '';
       const newBuf = buf.slice(0, -1);
@@ -355,13 +355,13 @@ const HomeView = () => {
         setupTimer(newBuf);
       }
 
-      if (value === 'Backspace') {
+      if (value === eventKey.Backspace) {
         const buf = inputBuffer ?? '';
         const newBuf = buf.slice(0, -1);
         setupTimer(newBuf);
       }
 
-      if (value === 'Enter') {
+      if (value === eventKey.Enter) {
         // Blur input
         const activeElement = document.activeElement as HTMLElement;
         if (activeElement.tagName === 'INPUT') {

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -22,9 +22,11 @@ import {
   setSetting
 } from '../../utils/settingsUtils';
 import { KEY_ENTER, KEY_NUMPAD_ENTER } from '../../constants/keys';
-
-const TIMER_INTERVAL_MS = 1;
-const MAX_TIME_SECONDS = 99 * 60 + 59;
+import {
+  TIMER_INTERVAL_MS,
+  MAX_TIMER_SECONDS,
+  MAX_CLOCK_MINUTES
+} from '../../constants/timer';
 
 const HomeView = () => {
   // Mode can be 'timer' or 'stopwatch'
@@ -58,6 +60,31 @@ const HomeView = () => {
     setSetting('timerInitial', timerInitial);
   }, [timerInitial]);
 
+  // Is count to timer
+  const [isCountToTimer, setIsCountToTimer] = useState<boolean>(
+    () => getSetting('isCountToTimer') as boolean
+  );
+  useEffect(() => {
+    setSetting('isCountToTimer', isCountToTimer);
+
+    // Reset input buffer
+    if (isCountToTimer) {
+      setInputBuffer('0000'); // 4 digits for HH:mm
+    } else {
+      setInputBuffer('000000'); // 6 digits for HH:mm:ss
+    }
+  }, [isCountToTimer]);
+
+  // Count to (00:00 - 23:59, max 1439 minutes)
+  const [countTo, setCountTo] = useState<number | null>(
+    () => (getSetting('countTo') as number) || null
+  );
+  useEffect(() => {
+    if (countTo !== null) {
+      setSetting('countTo', countTo);
+    }
+  }, [countTo]);
+
   // Progress circle
   const [circleSeconds, setCircleSeconds] = useState<number>(
     mode === Mode.Timer ? timerInitial : 60
@@ -65,6 +92,11 @@ const HomeView = () => {
 
   // Buffer for typed digits in timer mode
   const [inputBuffer, setInputBuffer] = useState<string | null>(null);
+  useEffect(() => {
+    if (inputBuffer !== null) {
+      setSetting('inputBuffer', inputBuffer);
+    }
+  }, [inputBuffer]);
 
   const [isRunning, setIsRunning] = useState(false);
   const [hasStarted, setHasStarted] = useState(false);
@@ -99,7 +131,7 @@ const HomeView = () => {
   useEffect(() => {
     if (isRunning) {
       // Stop the stopwatch if seconds larger than 99:59
-      if (seconds >= MAX_TIME_SECONDS) {
+      if (seconds >= MAX_TIMER_SECONDS) {
         setIsRunning(false);
       }
 
@@ -128,20 +160,11 @@ const HomeView = () => {
     };
   }, [isRunning, seconds, mode]);
 
-  const formatTime = (secs: number) => {
-    const secsInt = Math.max(0, Math.floor(secs));
-    const m = Math.floor(secsInt / 60)
-      .toString()
-      .padStart(2, '0');
-    const s = (secsInt % 60).toString().padStart(2, '0');
-    return `${m}:${s}`;
-  };
-
   // Handle input change
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const [m, s] = e.target.value.split(':').map(Number);
     if (!isNaN(m) && !isNaN(s)) {
-      const total = Math.min(m * 60 + s, MAX_TIME_SECONDS);
+      const total = Math.min(m * 60 + s, MAX_TIMER_SECONDS);
       setSeconds(total);
     }
   };
@@ -150,57 +173,30 @@ const HomeView = () => {
   const handleTimeAdjust = useCallback(
     (amount: number) => {
       setSeconds(prev =>
-        Math.min(Math.max(prev + amount, 0), MAX_TIME_SECONDS)
+        Math.min(Math.max(prev + amount, 0), MAX_TIMER_SECONDS)
       );
 
       if (mode === Mode.Timer) {
         setTimerInitial(prev =>
-          Math.min(Math.max(prev + amount, 0), MAX_TIME_SECONDS)
+          Math.min(Math.max(prev + amount, 0), MAX_TIMER_SECONDS)
         );
 
         setCircleSeconds(prev =>
-          Math.min(Math.max(prev + amount, 0), MAX_TIME_SECONDS)
+          Math.min(Math.max(prev + amount, 0), MAX_TIMER_SECONDS)
         );
       }
     },
     [mode]
   );
 
-  // Handle numeric key input shifting digits into mm:ss format
-  const handleTimeKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
-    if (mode !== Mode.Timer) return;
-    if (e.key >= '0' && e.key <= '9') {
-      e.preventDefault();
-      const digit = e.key;
-      const buf = (inputBuffer ?? '') + digit;
-      const newBuf = buf.length > 4 ? buf.slice(-4) : buf;
-      const padded = newBuf.padStart(4, '0');
-      const mm = parseInt(padded.slice(0, 2), 10);
-      const ss = parseInt(padded.slice(2), 10);
-      const totalSeconds = Math.min(mm * 60 + ss, MAX_TIME_SECONDS);
-      setSeconds(totalSeconds);
-      setTimerInitial(totalSeconds);
-      setCircleSeconds(totalSeconds);
-      setInputBuffer(newBuf);
-    } else if (e.key === 'Backspace') {
-      e.preventDefault();
-      const buf = inputBuffer ?? '';
-      const newBuf = buf.slice(0, -1);
-      const padded = newBuf.padStart(4, '0');
-      const mm = parseInt(padded.slice(0, 2), 10);
-      const ss = parseInt(padded.slice(2), 10);
-      const totalSeconds = Math.min(mm * 60 + ss, MAX_TIME_SECONDS);
-      setSeconds(totalSeconds);
-      setTimerInitial(totalSeconds);
-      setCircleSeconds(totalSeconds);
-      setInputBuffer(newBuf);
-    }
-  };
-
   // On focus, start editing buffer
   const handleTimeFocus = () => {
     if (mode === Mode.Timer) {
-      setInputBuffer('0000');
+      if (isCountToTimer) {
+        setInputBuffer('0000'); // 4 digits for HH:mm
+      } else {
+        setInputBuffer('000000'); // 6 digits for HH:mm:ss
+      }
       setIsEditing(true);
     }
   };
@@ -209,7 +205,32 @@ const HomeView = () => {
   const handleTimeBlur = () => {
     setInputBuffer(null);
     setIsEditing(false);
+
+    // Clear input buffer
+    if (isCountToTimer) {
+      setInputBuffer('0000'); // 4 digits for HH:mm
+    } else {
+      setInputBuffer('000000'); // 6 digits for HH:mm:ss
+    }
   };
+
+  // Refresh count to timer (with new current time)
+  const resetCountToTimer = useCallback(() => {
+    if (isCountToTimer) {
+      // Current time in minutes
+      const now = new Date();
+      const currentTimeInMinutes = now.getHours() * 60 + now.getMinutes();
+      const countToInMinutes = Math.min(countTo ?? 0, MAX_CLOCK_MINUTES);
+      let totalMinutes = countToInMinutes - currentTimeInMinutes;
+      if (totalMinutes < 0) {
+        totalMinutes += 24 * 60;
+      }
+      const totalSeconds = Math.min(totalMinutes * 60, MAX_TIMER_SECONDS);
+      setSeconds(totalSeconds);
+      setTimerInitial(totalSeconds);
+      setCircleSeconds(totalSeconds);
+    }
+  }, [isCountToTimer, countTo]);
 
   // start the timer
   const handleStart = useCallback(() => {
@@ -218,7 +239,15 @@ const HomeView = () => {
       setHasStarted(true);
     }
     setIsRunning(true);
-  }, [hasStarted]);
+
+    if (isCountToTimer) {
+      // Refresh count to timer with new current time
+      resetCountToTimer();
+
+      // reset to timer mode
+      setIsCountToTimer(false);
+    }
+  }, [hasStarted, isCountToTimer, resetCountToTimer]);
 
   // Pause the timer
   const handlePause = useCallback(() => {
@@ -234,9 +263,10 @@ const HomeView = () => {
     if (mode === Mode.Stopwatch) {
       setSeconds(0);
     }
+
     setIsRunning(false);
     setHasStarted(false);
-    document.body.style.backgroundColor = '';
+    document.body.style.backgroundColor = ''; // reset flashed background
   }, [mode, timerInitial]);
 
   // Handle keydown event
@@ -261,36 +291,77 @@ const HomeView = () => {
     [isRunning, handleStart, handlePause]
   );
 
+  // From the input buffer value, setup the timer
+  const setupTimer = useCallback(
+    (newBuf: string) => {
+      if (!isCountToTimer) {
+        const padded = newBuf.padStart(6, '0');
+        const HH = parseInt(padded.slice(0, 2), 10);
+        const mm = parseInt(padded.slice(2, 4), 10);
+        const ss = parseInt(padded.slice(4), 10);
+        const totalSeconds = Math.min(
+          HH * 60 * 60 + mm * 60 + ss,
+          MAX_TIMER_SECONDS
+        );
+        setSeconds(totalSeconds);
+        setTimerInitial(totalSeconds);
+        setCircleSeconds(totalSeconds);
+        setInputBuffer(newBuf);
+      }
+
+      if (isCountToTimer) {
+        const padded = newBuf.padStart(4, '0');
+        const HH = parseInt(padded.slice(0, 2), 10);
+        const mm = parseInt(padded.slice(2), 10);
+        const countToInMinutes = Math.min(HH * 60 + mm, MAX_CLOCK_MINUTES);
+        setCountTo(countToInMinutes);
+        setInputBuffer(newBuf);
+      }
+    },
+    [isCountToTimer]
+  );
+
+  // Handle numeric key input shifting digits into mm:ss format
+  const handleTimeKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (mode !== Mode.Timer) return;
+
+    const bufferLength = isCountToTimer ? 4 : 6;
+    if (e.key >= '0' && e.key <= '9') {
+      e.preventDefault();
+      const digit = e.key;
+      const buf = (inputBuffer ?? '') + digit;
+      const newBuf = buf.length > bufferLength ? buf.slice(-bufferLength) : buf;
+      setupTimer(newBuf);
+    }
+
+    if (e.key === 'Backspace') {
+      e.preventDefault();
+      const buf = inputBuffer ?? '';
+      const newBuf = buf.slice(0, -1);
+      setupTimer(newBuf);
+    }
+  };
+
   // Handle keypad input
   const handleKeypadPress = useCallback(
     (value: string | number) => {
       if (mode !== Mode.Timer) return;
 
+      const bufferLength = isCountToTimer ? 4 : 6;
       if (typeof value === 'number') {
         const buf = (inputBuffer ?? '') + value.toString();
-        const newBuf = buf.length > 4 ? buf.slice(-4) : buf;
-        const padded = newBuf.padStart(4, '0');
-        const mm = parseInt(padded.slice(0, 2), 10);
-        const ss = parseInt(padded.slice(2), 10);
-        const totalSeconds = Math.min(mm * 60 + ss, MAX_TIME_SECONDS);
+        const newBuf =
+          buf.length > bufferLength ? buf.slice(-1 * bufferLength) : buf;
+        setupTimer(newBuf);
+      }
 
-        setSeconds(totalSeconds);
-        setTimerInitial(totalSeconds);
-        setCircleSeconds(totalSeconds);
-        setInputBuffer(newBuf);
-      } else if (value === 'Backspace') {
+      if (value === 'Backspace') {
         const buf = inputBuffer ?? '';
         const newBuf = buf.slice(0, -1);
-        const padded = newBuf.padStart(4, '0');
-        const mm = parseInt(padded.slice(0, 2), 10);
-        const ss = parseInt(padded.slice(2), 10);
-        const totalSeconds = Math.min(mm * 60 + ss, MAX_TIME_SECONDS);
+        setupTimer(newBuf);
+      }
 
-        setSeconds(totalSeconds);
-        setTimerInitial(totalSeconds);
-        setCircleSeconds(totalSeconds);
-        setInputBuffer(newBuf);
-      } else if (value === 'Enter') {
+      if (value === 'Enter') {
         // Blur input
         const activeElement = document.activeElement as HTMLElement;
         if (activeElement.tagName === 'INPUT') {
@@ -304,8 +375,21 @@ const HomeView = () => {
         }
       }
     },
-    [mode, inputBuffer, handleStart, handlePause, isRunning]
+    [
+      mode,
+      isCountToTimer,
+      inputBuffer,
+      setupTimer,
+      isRunning,
+      handlePause,
+      handleStart
+    ]
   );
+
+  // Handle wave dash change
+  const handleWaveDashChange = () => {
+    setIsCountToTimer(prev => !prev);
+  };
 
   useEffect(() => {
     // Handle keydown event
@@ -360,17 +444,18 @@ const HomeView = () => {
           <div className={styles.inner}>
             <ModeSwitch mode={mode} onModeChange={handleModeChange} />
             <Time
-              seconds={formatTime(seconds)}
-              timerInitial={formatTime(timerInitial)}
-              milliseconds={Math.floor((seconds % 1) * 100)
-                .toString()
-                .padStart(2, '0')}
-              onChange={mode === Mode.Timer ? handleInputChange : undefined}
-              readOnly={isRunning || mode === Mode.Stopwatch}
+              seconds={seconds}
+              timerInitial={timerInitial}
+              onChange={handleInputChange}
               onKeyDown={handleTimeKeyDown}
               onFocus={handleTimeFocus}
               onBlur={handleTimeBlur}
+              onWaveDashClick={handleWaveDashChange}
               mode={mode}
+              isCountToTimer={isCountToTimer}
+              countTo={countTo}
+              isEditable={!isRunning && mode === Mode.Timer}
+              isEditing={isEditing}
             />
             {isEditing && <Keypad onKeyPress={handleKeypadPress} />}
             {!isEditing && (


### PR DESCRIPTION
该 PR 调整了 UI 的显示，使之支持 Count To 模式（即，输入一个时间，自动计算剩余时间，并开始计时）。
Count To 模式可以通过点击编辑模式的左侧的 【~】按钮 切换。

![image](https://github.com/user-attachments/assets/e2d36ee1-e1a4-4891-9d04-ceb8e2ab2d41)

其他修改：

1. 提高了最大可输入时间的上限：99分钟29秒 →　99小时59分钟59秒
2. 在 Timer 的右侧增加了毫秒，或总时间的显示，可通过触摸切换
   总时间使用 12h30 表示 12个小时30分钟，12m30 表示12分钟30秒

---

feat: count to timer

fix: wave dash state

fix: font size of milliseconds

feat: increase max time

feat: input buffer support hour

feat: display seconds

fix: count to timer display

feat: input buffer for debug

fix: input buffer clear

fix: milliseconds display

feat: switch sub text when isEditing change

fix: refresh count to timer

fix: refresh count down timer

fix: move refresh countToTimer

feat: show count to

refactor: reduce time utils

feat: use the latest count to time

fix: remove the mode countTo

fix: small improve